### PR TITLE
(PE-21284) Update Sensu tag

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -50,7 +50,7 @@ mod 'jfryman/nginx',         git: 'http://github.com/jfryman/puppet-nginx',     
 mod 'puppetlabs/tomcat',     git: 'https://github.com/puppetlabs/puppetlabs-tomcat',     tag: '1.5.0'
 
 mod 'rtyler/jenkins',        git: 'https://github.com/jenkinsci/puppet-jenkins',         tag: 'v1.6.1'
-mod 'sensu/sensu',           git: 'https://github.com/sensu/sensu-puppet',               tag: '2.1.0'
+mod 'sensu/sensu',           git: 'https://github.com/sensu/sensu-puppet',               tag: 'v2.1.0'
 mod 'bfraser/grafana',       git: 'https://github.com/bfraser/puppet-grafana',           tag: 'v2.5.0'
 
 mod 'elasticsearch/elasticsearch',     git: 'https://github.com/elastic/puppet-elasticsearch',     tag: '0.11.0'


### PR DESCRIPTION
It would appear that the upstream sensu repo has updated its tags to use a "v" in front of their version numbers and removed non-v versions. This breaks our Puppetfile and causes the test that uses this environment to fail.